### PR TITLE
Fix expansion file exists check

### DIFF
--- a/src/android/XAPKDownloaderActivity.java
+++ b/src/android/XAPKDownloaderActivity.java
@@ -39,8 +39,9 @@ public class XAPKDownloaderActivity extends Activity implements IDownloaderClien
      *
      * @return true if they are present.
      */
-    boolean expansionFilesDelivered(boolean mainVersion, int patchVersion, long fileSize) {
-        String fileName = Helpers.getExpansionAPKFileName(this, mainVersion, patchVersion);
+    boolean expansionFilesDelivered(int mainVersion, long fileSize) {
+        String fileName = Helpers.getExpansionAPKFileName(this, true, mainVersion);
+
         if (!Helpers.doesFileExist(this, fileName, fileSize, false)) {
             Log.e(LOG_TAG, "ExpansionAPKFile doesn't exist or has a wrong size (" + fileName + ").");
             return false;
@@ -53,13 +54,12 @@ public class XAPKDownloaderActivity extends Activity implements IDownloaderClien
     {
         super.onCreate(savedInstanceState);
 
-        boolean mainVersion = this.getIntent().getIntExtra("mainVersion", 1) > 0 ? true : false;
-        int patchVersion = this.getIntent().getIntExtra("patchVersion", 1);
+        int mainVersion = this.getIntent().getIntExtra("mainVersion", 1);
         long fileSize = this.getIntent().getLongExtra("fileSize", 0L);
         boolean downloadOption = this.getIntent().getBooleanExtra("downloadOption",true); 
 
         // Check if expansion files are available before going any further
-        if (!expansionFilesDelivered(mainVersion, patchVersion, fileSize)) {
+        if (!expansionFilesDelivered(mainVersion, fileSize)) {
 
             if(downloadOption == true) {
                 try {


### PR DESCRIPTION
getExpansionAPKFileName expects to get either (true, main expansion file version) or (false, patch expansion file version). Code was passing (true, patch file version). The code only worked when the version of the main file was 1. Google play selects the version using the version code of the apk that was uploaded when you upload the expansion file.

This change makes it possible to use main file, but patch file is still not properly supported. You need to check if main or patch are requested (versioncode > 0) and then check for each file. This also means you have ask for the file size of the patch, or drop the file size check.
